### PR TITLE
HTML markup improvements

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>404</title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="/style.css">
     <link rel="stylesheet" type="text/css" href="/cyber.css">
     <style type="text/css">

--- a/404.html
+++ b/404.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>404</title>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>lainon.life</title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="/style.css">
     <link rel="stylesheet" type="text/css" href="/cyber.css">
   </head>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>lainon.life</title>

--- a/radio.html
+++ b/radio.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>lainon.life radio</title>

--- a/radio.html
+++ b/radio.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>lainon.life radio</title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="/style.css">
     <link rel="stylesheet" type="text/css" href="/cyber.css">
     <script defer src="/radio.js" type="text/javascript"></script>

--- a/thankyou.html
+++ b/thankyou.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>lainon.life radio voice-overs</title>

--- a/thankyou.html
+++ b/thankyou.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>lainon.life radio voice-overs</title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="/style.css">
     <link rel="stylesheet" type="text/css" href="/cyber.css">
   </head>

--- a/voice.html
+++ b/voice.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>lainon.life radio voice-overs</title>

--- a/voice.html
+++ b/voice.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>lainon.life radio voice-overs</title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="/style.css">
     <link rel="stylesheet" type="text/css" href="/cyber.css">
   </head>


### PR DESCRIPTION
Tiny fix. Silences validator errors and removes warnings. Split into two commits just in case UTF-8 somehow messes things up.

https://www.w3.org/TR/html5/syntax.html#the-doctype
https://www.w3.org/TR/html5/document-metadata.html#charset