### PR TITLE
Start mpd playing if it's not already

### DIFF
--- a/backend/stream.py
+++ b/backend/stream.py
@@ -51,6 +51,10 @@ def start_stream_monitor(channelsjson, prometheus):
 
 def get_playlist_info(client, beforeNum=5, afterNum=5):
     status = client.status()
+    if status["state"] != "play":
+        print(f"MPD is not playing (state '{status['state']}') - starting")
+        client.play()
+        status = client.status()
     song = int(status["song"])
     pllen = int(status["playlistlength"])
 

--- a/scripts/schedule.py
+++ b/scripts/schedule.py
@@ -131,6 +131,9 @@ def schedule_radio(client, target_dur=3 * 60 * 60):
     client.random(0)
     client.repeat(1)
 
+    # Make sure it's playing
+    client.play()
+
     # Add tracks
     client.add(transition)
     client.findadd("album", album)


### PR DESCRIPTION
MPD should always be playing, but today it stopped at 7AM and didn't
start again.

An alternative approach would be to introduce a separate systemd unit
to monitor MPD and give it a kick if it's not in the right state, but
since not playing triggers an error from the backend, it can be fixed
here too.