### PR TITLE
Add mediaSession support to make notifications look nicer

### DIFF
--- a/frontend/js/radio.js
+++ b/frontend/js/radio.js
@@ -43,8 +43,18 @@ function populate_channel_list() {
 }
 
 function check_playlist() {
-    function format_track(track){
+    function format_track(track) {
         return (track.artist) ? (track.artist + " - " + track.title) : track.title;
+    }
+
+    function set_media_session(track) {
+        if ('mediaSession' in navigator) {
+            navigator.mediaSession.metadata = new MediaMetadata({
+                title: track.title,
+                artist: track.artist,
+                album: track.album,
+            });
+        }	
     }
 
     function add_track_to_tbody(tbody, track, acc, ago) {
@@ -92,6 +102,7 @@ function check_playlist() {
         // Update the "now playing"
         document.getElementById("nowplaying").innerText = format_track(response.current);
         document.getElementById("nowalbum").innerText = response.current.album;
+        set_media_session(response.current);
 
         let new_playlist = document.createElement("tbody");
         let until = parseFloat(response.current.time) - parseFloat(response.elapsed);


### PR DESCRIPTION
I recently used it on my phone again and viewed it as an improvement, I am probably the only person who uses it mobile anyway.

There is also the option for an icon as well, i think chrome on android just uses the favicon, but I am not 100% sure.

For reference, this is how gnome displays it:
![image](https://user-images.githubusercontent.com/15641615/128056188-c6dfa7dd-9017-413e-9e22-a5354b351b02.png)
